### PR TITLE
feat: 온보딩 용도 설정 화면 디자인 완성 - 사용자 이름 하얀색 플레이스홀더 추가로 디자인 연속성 확보 - 초록색 섹션…

### DIFF
--- a/lib/screens/onboarding/onboarding_input_screen.dart
+++ b/lib/screens/onboarding/onboarding_input_screen.dart
@@ -46,7 +46,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
     _nicknameController.text = '털찐 말랑이';
     _selectedLocation = '우리집 거실';
     _selectedDuration = '3개월';
-    _objectTypeController.text = '이 빨간 머그컵';
+    _objectTypeController.text = '이 빠진 머그컵';
   }
 
   @override
@@ -112,6 +112,13 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.of(context).size.width;
+    
+    // 화면 크기에 따른 반응형 높이 계산
+    final blueHeight = screenHeight * 0.16; // 화면 높이의 16% (최소 120, 최대 150)
+    final pinkHeight = screenHeight * 0.35; // 화면 높이의 35% (최소 280, 최대 320)
+    
     return Scaffold(
       resizeToAvoidBottomInset: true, // 키보드 오버플로우 방지
       // 일반적인 AppBar 사용
@@ -142,33 +149,26 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
             Container(
               width: double.infinity,
               color: const Color(0xFFFDF7E9),
-              padding: const EdgeInsets.fromLTRB(40, 32, 20, 32), // Material 3 표준 32dp
-              child: const Text(
-                '궁금해!\n나는 어떤 사람이야?',
+              padding: EdgeInsets.fromLTRB(screenWidth * 0.1, 32, screenWidth * 0.05, 32), // 상하 패딩 증가 (24 → 32)
+              child: Text(
+                '궁금해!\n나는 어떤 사물이야?',
                 style: TextStyle(
-                  fontSize: 28, // Material 3 Headline Medium
-                  fontWeight: FontWeight.bold,
+                  fontSize: screenWidth * 0.06, // 폰트 크기 줄임 (0.07 → 0.06)
+                  fontWeight: FontWeight.w600, // Material 3 표준 (bold → w600)
                   color: Colors.black,
-                  height: 1.2,
+                  height: 1.5, // 줄 간격 넓게 (1.3 → 1.5)
                 ),
               ),
             ),
             
-            // 하늘색 섹션 (100% 폭) - 최적화된 높이
+            // 하늘색 섹션 (100% 폭) - 반응형 높이
             Stack(
               children: [
                 Container(
                   width: double.infinity,
-                  height: 144, // Material 3 기준 최적화 (150 → 144)
+                  height: blueHeight.clamp(120.0, 150.0), // 최소 120, 최대 150
                   decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      colors: [
-                        Colors.blue.shade400,
-                        Colors.blue.shade600,
-                      ],
-                      begin: Alignment.topLeft,
-                      end: Alignment.bottomRight,
-                    ),
+                    color: const Color(0xFF57B3E6), // 단색으로 변경
                     border: Border.all(
                       color: Colors.black,
                       width: 1,
@@ -190,13 +190,13 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
                 
                 // 이름 입력 floating 카드
                 Positioned(
-                  top: 44, // 중앙 배치 최적화
-                  left: 40,
-                  right: 40,
+                  top: (blueHeight.clamp(120.0, 150.0) - 56) / 2 - 10, // 중앙 배치 (카드 높이 56 고려)
+                  left: screenWidth * 0.1, // 반응형 좌우 여백
+                  right: screenWidth * 0.1,
                   child: Column(
                     children: [
                       _buildNameInputCard(),
-                      const SizedBox(height: 4),
+                      const SizedBox(height: 8),
                       Align(
                         alignment: Alignment.centerRight,
                         child: Text(
@@ -214,16 +214,16 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
               ],
             ),
             
-            // 분홍색 섹션 (100% 폭 + 테두리 겹치기) - 최적화된 높이
+            // 분홍색 섹션 (100% 폭 + 테두리 겹치기) - 반응형 높이
             Transform.translate(
               offset: const Offset(0, -1), // 테두리 겹치기
               child: Stack(
                 children: [
                   Container(
                     width: double.infinity,
-                    height: 310, // 입력 필드 개수에 맞춰 최적화
+                    height: pinkHeight.clamp(320.0, 380.0), // 400→320, 460→380으로 줄임 (상하 균일하게)
                     decoration: BoxDecoration(
-                      color: const Color(0xFFE1BEE7),
+                      color: const Color(0xFFFFD8F1), // 색상 변경
                       border: Border.all(
                         color: Colors.black,
                         width: 1,
@@ -240,11 +240,11 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
                     ),
                   ),
                   
-                  // 입력 폼 floating 카드
+                  // 입력 폼 floating 카드 - 상하 중앙 배치
                   Positioned(
-                    top: 48, // Material 3 기준 최적화
-                    left: 40,
-                    right: 40,
+                    top: 48, // 56→48로 조정 (상하 여백 균일하게)
+                    left: screenWidth * 0.1, // 반응형 좌우 여백
+                    right: screenWidth * 0.1,
                     child: _buildInputFormCard(),
                   ),
                 ],
@@ -256,7 +256,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
               Container(
                 width: double.infinity,
                 color: const Color(0xFFFDF7E9),
-                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16), // Material 3 표준
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16), // 16은 8배수로 유지
                 child: Text(
                   _validationError!,
                   style: const TextStyle(
@@ -271,7 +271,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
             Container(
               width: double.infinity,
               color: const Color(0xFFFDF7E9),
-              padding: const EdgeInsets.fromLTRB(24, 24, 24, 48), // Material 3 표준
+              padding: EdgeInsets.fromLTRB(screenWidth * 0.06, 24, screenWidth * 0.06, 48), // 반응형 패딩
               child: _buildNextButton(),
             ),
           ],
@@ -288,15 +288,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
         decoration: BoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.circular(28), // 다음 버튼과 동일한 라운딩
-          border: Border.all(color: Colors.black, width: 1),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.08),
-              spreadRadius: 0,
-              blurRadius: 4,
-              offset: const Offset(0, 1),
-            ),
-          ],
+          border: Border.all(color: Colors.transparent, width: 0), // 테두리 제거
         ),
         child: Row(
           children: [
@@ -305,7 +297,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
               '애칭',
               style: TextStyle(
                 color: Colors.grey.shade600,
-                fontSize: 16,
+                fontSize: 14, // 16 → 14로 축소 (애칭 레이블 작게)
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -319,7 +311,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
                     color: _nicknameController.text.isNotEmpty 
                         ? Colors.black 
                         : Colors.grey, // 건너뛰기와 같은 색상
-                    fontSize: 20, // 텍스트 크기 증가 (16 → 20)
+                    fontSize: 20, // 14 → 20으로 복원 (예시 텍스트 크기 원래대로)
                     fontWeight: FontWeight.w600, // 더 굵게
                   ),
                 ),
@@ -348,7 +340,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
           }
         ),
         
-        const SizedBox(height: 8), // 12 → 8로 더 좁게 (Material 3 최소 간격)
+        const SizedBox(height: 8), // 4 → 8 (8배수 간격)
         
         // 기간 드롭다운
         _buildDropdownRow(
@@ -363,98 +355,10 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
           }
         ),
         
-        const SizedBox(height: 8), // 12 → 8로 더 좁게 (Material 3 최소 간격)
+        const SizedBox(height: 8), // 4 → 8 (8배수 간격)
         
         // 사물 종류 입력 (애칭과 같은 형태로 변경)
         _buildObjectTypeCard(),
-      ],
-    );
-  }
-
-  Widget _buildDropdownRow(String? selectedValue, List<String> options, String suffix, String preview, Function(String?) onChanged) {
-    return Column(
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(28), // 다음 버튼과 동일한 라운딩
-                  border: Border.all(color: Colors.grey.shade300, width: 1),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.08),
-                      spreadRadius: 0,
-                      blurRadius: 4,
-                      offset: const Offset(0, 1),
-                    ),
-                  ],
-                ),
-                child: Container(
-                  height: 56, // 다음 버튼과 동일한 높이
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(28), // 다음 버튼과 동일한 라운딩
-                  ),
-                  child: DropdownButtonHideUnderline(
-                    child: DropdownButton<String>(
-                      value: selectedValue,
-                      isExpanded: true,
-                      icon: const Icon(Icons.keyboard_arrow_down, color: Colors.grey, size: 24),
-                      hint: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: Text(
-                          preview,
-                          style: const TextStyle(
-                            color: Colors.grey, // 건너뛰기와 같은 색상
-                            fontSize: 18, // Material 3 Body Large+ (16 → 18)
-                            fontWeight: FontWeight.w500, // 약간 더 굵게
-                          ),
-                        ),
-                      ),
-                      style: const TextStyle(
-                        color: Colors.black,
-                        fontSize: 18, // Material 3 Body Large+ (16 → 18)
-                        fontWeight: FontWeight.w500, // 약간 더 굵게
-                      ),
-                      items: options.map((String value) {
-                        return DropdownMenuItem<String>(
-                          value: value,
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 16),
-                            child: Text(value),
-                          ),
-                        );
-                      }).toList(),
-                      onChanged: onChanged,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(width: 12),
-            Text(
-              suffix,
-              style: const TextStyle(
-                fontSize: 16, // Material 3 Body Large
-                fontWeight: FontWeight.w500,
-                color: Colors.black,
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 4), // 작은 간격
-        Align(
-          alignment: Alignment.centerRight,
-          child: Text(
-            selectedValue == null ? '선택해주세요' : '',
-            style: TextStyle(
-              color: Colors.red.shade400,
-              fontSize: 10, // Material 3 Caption
-              fontWeight: FontWeight.w400,
-            ),
-          ),
-        ),
       ],
     );
   }
@@ -472,49 +376,30 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
                   decoration: BoxDecoration(
                     color: Colors.white,
                     borderRadius: BorderRadius.circular(28), // 다음 버튼과 동일한 라운딩
-                    border: Border.all(color: Colors.grey.shade300, width: 1), // 다른 필드와 동일한 테두리
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withOpacity(0.08),
-                        spreadRadius: 0,
-                        blurRadius: 4,
-                        offset: const Offset(0, 1),
-                      ),
-                    ],
+                    border: Border.all(color: Colors.transparent, width: 0), // 테두리 제거
                   ),
-                  child: Row(
-                    children: [
-                      const SizedBox(width: 16),
-                      Text(
-                        '종류',
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        _objectTypeController.text.isNotEmpty 
+                            ? _objectTypeController.text 
+                            : '이 빠진 머그컵', // 미리보기 텍스트
                         style: TextStyle(
-                          color: Colors.grey.shade600,
-                          fontSize: 16, // Material 3 Body Large
-                          fontWeight: FontWeight.w500,
+                          color: _objectTypeController.text.isNotEmpty 
+                              ? Colors.grey  // Colors.black → Colors.grey로 변경
+                              : Colors.grey, // 건너뛰기와 같은 색상
+                          fontSize: 18, // Material 3 Body Large+ (16 → 18)
+                          fontWeight: FontWeight.w500, // 약간 더 굵게
                         ),
                       ),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: Text(
-                          _objectTypeController.text.isNotEmpty 
-                              ? _objectTypeController.text 
-                              : '이 빨간 머그컵', // 미리보기 텍스트
-                          style: TextStyle(
-                            color: _objectTypeController.text.isNotEmpty 
-                                ? Colors.black 
-                                : Colors.grey, // 건너뛰기와 같은 색상
-                            fontSize: 18, // Material 3 Body Large+ (16 → 18)
-                            fontWeight: FontWeight.w500, // 약간 더 굵게
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 16),
-                    ],
+                    ),
                   ),
                 ),
               ),
             ),
-            const SizedBox(width: 12),
+            const SizedBox(width: 8), // 12 → 8 (8배수 간격)
             Text(
               '(이)에요.',
               style: const TextStyle(
@@ -525,7 +410,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
             ),
           ],
         ),
-        const SizedBox(height: 4), // 작은 간격
+        const SizedBox(height: 8), // 8배수 간격
         Align(
           alignment: Alignment.centerRight,
           child: Text(
@@ -541,6 +426,153 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
     );
   }
 
+  Widget _buildDropdownRow(String? selectedValue, List<String> options, String suffix, String preview, Function(String?) onChanged) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: GestureDetector(
+                onTap: () => _showCustomDropdown(context, options, selectedValue, onChanged, offsetY: options == _locationOptions ? 98 : 124),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(28),
+                    border: Border.all(color: Colors.transparent, width: 0), // 테두리 제거
+                  ),
+                  child: Container(
+                    height: 56,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(28),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            selectedValue ?? preview,
+                            style: TextStyle(
+                              color: selectedValue != null ? Colors.black : Colors.grey,
+                              fontSize: 18,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          const Icon(Icons.keyboard_arrow_down, color: Colors.grey, size: 24),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              suffix,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+                color: Colors.black,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Text(
+            selectedValue == null ? '선택해주세요' : '',
+            style: TextStyle(
+              color: Colors.red.shade400,
+              fontSize: 10,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // 커스텀 드롭다운 표시 (오버레이 방식) - 개별 설정 가능
+  void _showCustomDropdown(BuildContext context, List<String> options, String? selectedValue, Function(String?) onChanged, {double offsetY = 80}) {
+    final RenderBox renderBox = context.findRenderObject() as RenderBox;
+    final position = renderBox.localToGlobal(Offset.zero);
+    
+    showDialog(
+      context: context,
+      barrierColor: Colors.black.withOpacity(0.3), // 배경 흐리게
+      builder: (BuildContext context) {
+        return Stack(
+          children: [
+            // 배경 터치하면 닫기
+            GestureDetector(
+              onTap: () => Navigator.pop(context),
+              child: Container(
+                color: Colors.transparent,
+                width: double.infinity,
+                height: double.infinity,
+              ),
+            ),
+            
+            // 드롭다운 박스 - 개별 오프셋 적용
+            Positioned(
+              left: 40,
+              right: 40,
+              top: position.dy + offsetY, // 개별 오프셋 적용
+              child: Material(
+                elevation: 8,
+                borderRadius: BorderRadius.circular(25),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(25),
+                    border: Border.all(color: Colors.black, width: 1), // 검은색 테두리 1px
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: options.asMap().entries.map((entry) {
+                      final index = entry.key;
+                      final option = entry.value;
+                      final isSelected = selectedValue == option;
+                      
+                      return GestureDetector(
+                        onTap: () {
+                          onChanged(option);
+                          Navigator.pop(context);
+                        },
+                        child: Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                          decoration: BoxDecoration(
+                            color: isSelected ? const Color(0xFFDAB7FA) : Colors.white, // 선택된 항목 #DAB7FA
+                            borderRadius: BorderRadius.only(
+                              topLeft: index == 0 ? const Radius.circular(10) : Radius.zero,
+                              topRight: index == 0 ? const Radius.circular(10) : Radius.zero,
+                              bottomLeft: index == options.length - 1 ? const Radius.circular(10) : Radius.zero,
+                              bottomRight: index == options.length - 1 ? const Radius.circular(10) : Radius.zero,
+                            ),
+                          ),
+                          child: Text(
+                            option,
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                              color: Colors.black,
+                            ),
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   Widget _buildNextButton() {
     return Container(
       width: double.infinity,
@@ -548,15 +580,7 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(28), // 높이에 맞는 라운딩
-        border: Border.all(color: Colors.grey.shade300, width: 1), // 다른 입력 필드와 통일
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.08), // Material 3 그림자로 통일
-            spreadRadius: 0,
-            blurRadius: 4,
-            offset: const Offset(0, 1),
-          ),
-        ],
+        border: Border.all(color: Colors.grey.shade400, width: 1), // 회색 외곽선으로 변경
       ),
       child: ElevatedButton(
         onPressed: _proceedToNext,
@@ -582,29 +606,145 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
   void _showNicknameDialog() {
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('애칭 설정'),
-        content: TextField(
-          controller: _nicknameController,
-          decoration: const InputDecoration(
-            hintText: '애칭을 입력해주세요',
-            border: OutlineInputBorder(),
+      barrierColor: const Color(0x4D000000), // Colors.black.withOpacity(0.3) → const로 최적화
+      barrierDismissible: true, // 성능 개선
+      builder: (context) => Dialog(
+        backgroundColor: Colors.transparent,
+        insetPadding: const EdgeInsets.all(40), // 기본값 명시로 최적화
+        child: Container(
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.all(Radius.circular(25)), // const로 최적화
+            border: Border.fromBorderSide(BorderSide(color: Colors.black, width: 1)), // const로 최적화
           ),
-          autofocus: true,
+          padding: const EdgeInsets.fromLTRB(24, 28, 24, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                '애칭 설정',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.grey.shade700,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Container(
+                height: 56,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: const BorderRadius.all(Radius.circular(28)), // const로 최적화
+                  border: Border.all(color: Colors.grey.shade300, width: 1),
+                ),
+                child: TextField(
+                  controller: _nicknameController,
+                  textAlign: TextAlign.center,
+                  decoration: InputDecoration(
+                    hintText: '애칭을 입력해주세요',
+                    hintStyle: TextStyle(
+                      color: Colors.grey.shade500,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w400,
+                    ),
+                    border: const OutlineInputBorder( // const로 최적화
+                      borderRadius: BorderRadius.all(Radius.circular(28)),
+                      borderSide: BorderSide.none,
+                    ),
+                    enabledBorder: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(28)),
+                      borderSide: BorderSide.none,
+                    ),
+                    focusedBorder: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(28)),
+                      borderSide: BorderSide.none,
+                    ),
+                    filled: true,
+                    fillColor: Colors.white,
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                    isDense: true,
+                  ),
+                  style: const TextStyle( // const로 최적화
+                    color: Colors.black87,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  autofocus: true,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 3),
+                      child: GestureDetector(
+                        onTap: () => Navigator.pop(context),
+                        child: Container(
+                          height: 40,
+                          decoration: BoxDecoration(
+                            color: Colors.grey.shade50,
+                            border: Border.all(color: Colors.grey.shade300, width: 1),
+                            borderRadius: const BorderRadius.only( // const로 최적화
+                              topLeft: Radius.circular(20),
+                              bottomLeft: Radius.circular(20),
+                              topRight: Radius.zero,
+                              bottomRight: Radius.zero,
+                            ),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '취소',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w200,
+                                color: Colors.grey.shade600,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 3),
+                      child: GestureDetector(
+                        onTap: () {
+                          setState(() {});
+                          Navigator.pop(context);
+                        },
+                        child: Container(
+                          height: 40,
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFDAB7FA).withOpacity(0.7),
+                            border: Border.all(color: const Color(0xFFDAB7FA).withOpacity(0.7), width: 1),
+                            borderRadius: const BorderRadius.only( // const로 최적화
+                              topLeft: Radius.zero,
+                              bottomLeft: Radius.zero,
+                              topRight: Radius.circular(20),
+                              bottomRight: Radius.circular(20),
+                            ),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '확인',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w200,
+                                color: Colors.grey.shade700,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('취소'),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              setState(() {}); // 버튼 텍스트 업데이트
-              Navigator.pop(context);
-            },
-            child: const Text('확인'),
-          ),
-        ],
       ),
     );
   }
@@ -613,29 +753,145 @@ class _OnboardingInputScreenState extends State<OnboardingInputScreen> {
   void _showObjectTypeDialog() {
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('사물 종류 설정'),
-        content: TextField(
-          controller: _objectTypeController,
-          decoration: const InputDecoration(
-            hintText: '사물의 종류를 입력해주세요',
-            border: OutlineInputBorder(),
+      barrierColor: const Color(0x4D000000), // Colors.black.withOpacity(0.3) → const로 최적화
+      barrierDismissible: true, // 성능 개선
+      builder: (context) => Dialog(
+        backgroundColor: Colors.transparent,
+        insetPadding: const EdgeInsets.all(40), // 기본값 명시로 최적화
+        child: Container(
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.all(Radius.circular(25)), // const로 최적화
+            border: Border.fromBorderSide(BorderSide(color: Colors.black, width: 1)), // const로 최적화
           ),
-          autofocus: true,
+          padding: const EdgeInsets.fromLTRB(24, 28, 24, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                '사물 종류 설정',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.grey.shade700,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Container(
+                height: 56,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: const BorderRadius.all(Radius.circular(28)), // const로 최적화
+                  border: Border.all(color: Colors.grey.shade300, width: 1),
+                ),
+                child: TextField(
+                  controller: _objectTypeController,
+                  textAlign: TextAlign.center,
+                  decoration: InputDecoration(
+                    hintText: '사물의 종류를 입력해주세요',
+                    hintStyle: TextStyle(
+                      color: Colors.grey.shade500,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w400,
+                    ),
+                    border: const OutlineInputBorder( // const로 최적화
+                      borderRadius: BorderRadius.all(Radius.circular(28)),
+                      borderSide: BorderSide.none,
+                    ),
+                    enabledBorder: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(28)),
+                      borderSide: BorderSide.none,
+                    ),
+                    focusedBorder: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(28)),
+                      borderSide: BorderSide.none,
+                    ),
+                    filled: true,
+                    fillColor: Colors.white,
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                    isDense: true,
+                  ),
+                  style: const TextStyle( // const로 최적화
+                    color: Colors.black87,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  autofocus: true,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 3),
+                      child: GestureDetector(
+                        onTap: () => Navigator.pop(context),
+                        child: Container(
+                          height: 40,
+                          decoration: BoxDecoration(
+                            color: Colors.grey.shade50,
+                            border: Border.all(color: Colors.grey.shade300, width: 1),
+                            borderRadius: const BorderRadius.only( // const로 최적화
+                              topLeft: Radius.circular(20),
+                              bottomLeft: Radius.circular(20),
+                              topRight: Radius.zero,
+                              bottomRight: Radius.zero,
+                            ),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '취소',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w200,
+                                color: Colors.grey.shade600,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 3),
+                      child: GestureDetector(
+                        onTap: () {
+                          setState(() {});
+                          Navigator.pop(context);
+                        },
+                        child: Container(
+                          height: 40,
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFDAB7FA).withOpacity(0.7),
+                            border: Border.all(color: const Color(0xFFDAB7FA).withOpacity(0.7), width: 1),
+                            borderRadius: const BorderRadius.only( // const로 최적화
+                              topLeft: Radius.zero,
+                              bottomLeft: Radius.zero,
+                              topRight: Radius.circular(20),
+                              bottomRight: Radius.circular(20),
+                            ),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '확인',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w200,
+                                color: Colors.grey.shade700,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('취소'),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              setState(() {}); // 텍스트 업데이트
-              Navigator.pop(context);
-            },
-            child: const Text('확인'),
-          ),
-        ],
       ),
     );
   }


### PR DESCRIPTION
… 색상 #3FCB80로 업데이트 - 제목 텍스트 크기 통일 (24px) - 말풍선 내부 레이아웃 Row로 변경 (용도 왼쪽, 입력 텍스트 오른쪽 정렬) - 초록색 섹션 내 말풍선 세로 중앙 배치 - 섹션별 여백 최적화 및 UI 균형 조정 - 빨간 경고 텍스트 오른쪽 정렬 - Material 3 가이드라인 준수