### PR TITLE
feat: 채팅 히스토리 화면 구현 - 사물 기반 채팅 리스트, 필터링, 새 채팅방 표시, 프로필/장소 사진, 읽지않은 메시…

### DIFF
--- a/lib/screens/chat/chat_history_screen.dart
+++ b/lib/screens/chat/chat_history_screen.dart
@@ -1,0 +1,534 @@
+import 'package:flutter/material.dart';
+
+class ChatHistoryScreen extends StatefulWidget {
+  const ChatHistoryScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ChatHistoryScreen> createState() => _ChatHistoryScreenState();
+}
+
+class _ChatHistoryScreenState extends State<ChatHistoryScreen> {
+  String _selectedFilter = 'all'; // 'all', 'moments', 'friends'
+
+  // 사물 기반 채팅 데이터
+  final List<ChatHistoryItem> _chatHistory = [
+    ChatHistoryItem(
+      id: '1',
+      username: 'starryskies23',
+      handle: '@starry',
+      avatar: 'assets/profile.png',
+      lastMessage: '내 방이 그 모이야',
+      timestamp: '1d',
+      isOnline: true,
+      category: 'moments',
+      objectName: '털찐 말랑이',
+      objectPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 사물 프로필 이미지 URL
+      unreadCount: 1,
+      hasUnread: true,
+      isNewChat: true, // 새로운 채팅방
+    ),
+    ChatHistoryItem(
+      id: '2',
+      username: 'nebulanomad',
+      handle: '@nebula',
+      avatar: 'assets/profile.png',
+      lastMessage: '명동쪽도 쉬고싶다며..파업한다며',
+      timestamp: '1d',
+      isOnline: true,
+      category: 'moments',
+      objectName: '도시락통',
+      objectPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 사물 프로필 이미지 URL
+      hasLocationPhoto: true,
+      locationPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 장소 이미지 URL
+      hasReaction: true,
+      isNewChat: true, // 새로운 채팅방
+    ),
+    ChatHistoryItem(
+      id: '3',
+      username: 'emberecho',
+      handle: '@ember',
+      avatar: 'assets/profile.png',
+      lastMessage: '내 매직시에 좋아요를 눌렀어요\n생추욱~~~!!! 🎉🎊',
+      timestamp: '2d',
+      isOnline: false,
+      category: 'moments',
+      objectName: '커피머그컵',
+      objectPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 사물 프로필 이미지 URL
+      hasLocationPhoto: true,
+      locationPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 장소 이미지 URL
+    ),
+    ChatHistoryItem(
+      id: '4',
+      username: 'lunavoyager',
+      handle: '@luna',
+      avatar: 'assets/profile.png',
+      lastMessage: '내 글을 저장했어요.',
+      timestamp: '3d',
+      isOnline: false,
+      category: 'moments',
+      objectName: '다이어리',
+      objectPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 사물 프로필 이미지 URL
+      hasLocationPhoto: true,
+      locationPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 장소 이미지 URL
+    ),
+    ChatHistoryItem(
+      id: '5',
+      username: 'shadowlynx',
+      handle: '@shadow',
+      avatar: 'assets/profile.png',
+      lastMessage: '내 매직시에 댓글을 남왔어요\n8월에 가능한 좋은 생각이야!\n너는 어디로 여행가고 싶어?',
+      timestamp: '4d',
+      isOnline: false,
+      category: 'moments',
+      objectName: '여행가방',
+      objectPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 사물 프로필 이미지 URL
+      hasLocationPhoto: true,
+      locationPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 장소 이미지 URL
+    ),
+    ChatHistoryItem(
+      id: '6',
+      username: 'nebulanomad',
+      handle: '@nebula2',
+      avatar: 'assets/profile.png',
+      lastMessage: '사진을 공유했어요.',
+      timestamp: '5d',
+      isOnline: false,
+      category: 'friends',
+      objectName: '친구 핸드폰',
+      objectPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 사물 프로필 이미지 URL
+      hasLocationPhoto: true,
+      locationPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 장소 이미지 URL
+      isVisitor: true,
+      hasReaction: true,
+      isNewChat: true, // 새로운 채팅방 (친구 오브젝트)
+    ),
+    ChatHistoryItem(
+      id: '7',
+      username: 'lunavoyager',
+      handle: '@luna2',
+      avatar: 'assets/profile.png',
+      lastMessage: '내 매직시에 좋아요를 눌렀어요\n정말 잘했다!!!',
+      timestamp: '5d',
+      isOnline: false,
+      category: 'friends',
+      objectName: '친구 노트북',
+      objectPhoto: 'assets/profile.png', // 실제로는 서버에서 받아온 사물 프로필 이미지 URL
+      hasUnread: true,
+      unreadCount: 3,
+      isVisitor: true,
+      hasReaction: true,
+    ),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  List<ChatHistoryItem> get _filteredChatHistory {
+    switch (_selectedFilter) {
+      case 'moments':
+        return _chatHistory
+            .where((chat) => chat.category == 'moments')
+            .toList();
+      case 'friends':
+        return _chatHistory
+            .where((chat) => chat.category == 'friends')
+            .toList();
+      case 'all':
+      default:
+        return _chatHistory;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white, // 흰색 배경
+      appBar: AppBar(
+        backgroundColor: const Color(0xFFFDF7E9), // 아이보리색 앱바
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text(
+          '챗 히스토리',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+            color: Colors.black,
+          ),
+        ),
+        centerTitle: false,
+      ),
+      body: Column(
+        children: [_buildFilterButtons(), Expanded(child: _buildChatList())],
+      ),
+    );
+  }
+
+  Widget _buildChatList() {
+    final filteredChats = _filteredChatHistory;
+
+    if (filteredChats.isEmpty) {
+      return const Center(
+        child: Text(
+          '채팅 내역이 없습니다',
+          style: TextStyle(fontSize: 16, color: Colors.grey),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      itemCount: filteredChats.length,
+      itemBuilder: (context, index) {
+        final chat = filteredChats[index];
+        return _buildChatItem(chat);
+      },
+    );
+  }
+
+  Widget _buildChatItem(ChatHistoryItem chat) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Material(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () => _openChat(chat),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                // 사물 프로필 사진 + 읽지 않은 메시지 마커
+                Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    CircleAvatar(
+                      radius: 24,
+                      backgroundImage: AssetImage(
+                        chat.objectPhoto ?? chat.avatar,
+                      ),
+                      backgroundColor: Colors.grey.shade200,
+                    ),
+                    // 새로운 채팅방 빨간 점 (절대 위치)
+                    if (chat.isNewChat)
+                      Positioned(
+                        left: -12,
+                        top: 20,
+                        child: Container(
+                          width: 8,
+                          height: 8,
+                          decoration: const BoxDecoration(
+                            color: Colors.red,
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                      ),
+                    if (chat.isOnline)
+                      Positioned(
+                        bottom: 0,
+                        right: 0,
+                        child: Container(
+                          width: 12,
+                          height: 12,
+                          decoration: BoxDecoration(
+                            color: Colors.green,
+                            shape: BoxShape.circle,
+                            border: Border.all(color: Colors.white, width: 2),
+                          ),
+                        ),
+                      ),
+                    // 읽지 않은 메시지 마커
+                    if (chat.hasUnread && chat.unreadCount > 0)
+                      Positioned(
+                        top: -2,
+                        right: -2,
+                        child: Container(
+                          padding: const EdgeInsets.all(4),
+                          decoration: const BoxDecoration(
+                            color: Colors.red,
+                            shape: BoxShape.circle,
+                          ),
+                          constraints: const BoxConstraints(
+                            minWidth: 20,
+                            minHeight: 20,
+                          ),
+                          child: Text(
+                            '${chat.unreadCount}',
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 11,
+                              fontWeight: FontWeight.bold,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(width: 12),
+
+                // 채팅 정보
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Row(
+                            children: [
+                              // 사물 애칭
+                              Text(
+                                chat.objectName ?? chat.username,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                  color: Colors.black,
+                                ),
+                              ),
+                              if (chat.isVisitor) ...[
+                                const SizedBox(width: 4),
+                                Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6,
+                                    vertical: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Colors.orange.shade100,
+                                    borderRadius: BorderRadius.circular(8),
+                                  ),
+                                  child: const Text(
+                                    '방문',
+                                    style: TextStyle(
+                                      fontSize: 10,
+                                      color: Colors.orange,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                          // 마지막 메시지 수신일
+                          Text(
+                            chat.timestamp,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey.shade500,
+                            ),
+                          ),
+                        ],
+                      ),
+                      // 사용자명 + 반응 알림
+                      Row(
+                        children: [
+                          Text(
+                            '@${chat.username}',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey.shade600,
+                              fontWeight: FontWeight.w400,
+                            ),
+                          ),
+                          if (chat.hasReaction) ...[
+                            const SizedBox(width: 4),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 4,
+                                vertical: 1,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.pink.shade50,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: Text(
+                                '❤️ 반응',
+                                style: TextStyle(
+                                  fontSize: 10,
+                                  color: Colors.pink.shade600,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      // 마지막 메시지
+                      Text(
+                        chat.lastMessage,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey.shade700,
+                          height: 1.3,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // 장소 사진 썸네일 및 읽지 않은 메시지 표시
+                Column(
+                  children: [
+                    if (chat.hasLocationPhoto)
+                      Container(
+                        width: 40,
+                        height: 40,
+                        margin: const EdgeInsets.only(left: 8),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(8),
+                          color: Colors.grey.shade200,
+                        ),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(8),
+                          child: Image.asset(
+                            chat.locationPhoto,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                      ),
+                    if (chat.hasUnread && chat.unreadCount == 0)
+                      Container(
+                        margin: const EdgeInsets.only(left: 8, top: 4),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 4,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.red,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: const Text(
+                          '더보기',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilterButtons() {
+    return Container(
+      color: const Color(0xFFFDF7E9), // 필터링란만 아이보리색
+      padding: const EdgeInsets.all(16), // 패딩을 다시 16으로 복원
+      child: Row(
+        children: [
+          _buildFilterButton('전체', 'all'),
+          const SizedBox(width: 12),
+          _buildFilterButton('내 모멘티', 'moments'),
+          const SizedBox(width: 12),
+          _buildFilterButton('@유저명', 'friends'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterButton(String title, String filterValue) {
+    final isSelected = _selectedFilter == filterValue;
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          _selectedFilter = filterValue;
+        });
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? Colors.black : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: isSelected ? Colors.black : Colors.grey.shade300,
+            width: 1,
+          ),
+        ),
+        child: Text(
+          title,
+          style: TextStyle(
+            color: isSelected ? Colors.white : Colors.grey.shade700,
+            fontSize: 14,
+            fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openChat(ChatHistoryItem chat) {
+    // 리스트 클릭 시 버튼 활성화 - 채팅 화면으로 이동
+    print('Opening chat with object: ${chat.objectName} by ${chat.username}');
+    // TODO: 실제 채팅 화면으로 네비게이션
+    showDialog(
+      context: context,
+      builder:
+          (context) => AlertDialog(
+            title: Text('${chat.objectName}과의 채팅'),
+            content: Text(
+              '${chat.username}님이 만든 ${chat.objectName}과 채팅을 시작합니다.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('확인'),
+              ),
+            ],
+          ),
+    );
+  }
+}
+
+class ChatHistoryItem {
+  final String id;
+  final String username;
+  final String handle;
+  final String avatar;
+  final String lastMessage;
+  final String timestamp;
+  final bool isOnline;
+  final String category;
+  final bool hasLocationPhoto;
+  final String locationPhoto;
+  final bool hasUnread;
+  final String? objectName; // 사물 애칭
+  final String? objectPhoto; // 사물 프로필 사진
+  final bool isVisitor;
+  final int unreadCount; // 읽지 않은 메시지 마커
+  final bool hasReaction; // 메시지에 대한 반응 알림
+  final bool isNewChat; // 새로운 채팅방
+
+  ChatHistoryItem({
+    required this.id,
+    required this.username,
+    required this.handle,
+    required this.avatar,
+    required this.lastMessage,
+    required this.timestamp,
+    this.isOnline = false,
+    required this.category,
+    this.hasLocationPhoto = false,
+    this.locationPhoto = '',
+    this.hasUnread = false,
+    this.objectName,
+    this.objectPhoto,
+    this.isVisitor = false,
+    this.unreadCount = 0,
+    this.hasReaction = false,
+    this.isNewChat = false,
+  });
+}

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -26,13 +26,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     // 현재 문제는 앱 시작부터 권한이 꼬이는 것이므로, 사용자 액션에 따라 요청하는 것이 더 안전할 수 있습니다.
     // print("HomeScreen initState: 권한 요청 로직은 사용자 액션 시점으로 이동 고려.");
 
-    _deeplinkWatcher =
-        Timer.periodic(Duration(milliseconds: 300), (timer) async {
+    _deeplinkWatcher = Timer.periodic(Duration(milliseconds: 300), (
+      timer,
+    ) async {
       if (pendingRoomId != null) {
         final roomId = pendingRoomId!;
         try {
-          print(
-              '🚨 [Timer] 딥링크로 ChatScreen 이동 시 캐릭터 정보 누락. roomId: $roomId');
+          print('🚨 [Timer] 딥링크로 ChatScreen 이동 시 캐릭터 정보 누락. roomId: $roomId');
         } catch (e) {
           print('❌ [Timer] 채팅방 이동 실패: $e');
         } finally {
@@ -64,14 +64,15 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       // 만약 이 시점에 STT가 활성화되어야 한다면 _requestMicrophonePermission를 호출할 수 있습니다.
       // 하지만 사용자가 마이크 버튼을 누르기 전까지는 필수가 아닐 수 있습니다.
       // 현재 상태를 확인하고 UI를 업데이트 하는 용도로만 사용할 수도 있습니다.
-       _requestMicrophonePermission(); // OS 설정 변경 후 돌아왔을 때 상태 갱신을 위해 호출 유지
+      _requestMicrophonePermission(); // OS 설정 변경 후 돌아왔을 때 상태 갱신을 위해 호출 유지
     }
   }
 
   Future<bool> _checkAndRequestMicrophonePermission() async {
     var status = await Permission.microphone.status;
     print(
-        "Checking permission: $status, isGranted: ${status.isGranted}, isDenied: ${status.isDenied}, isPermanentlyDenied: ${status.isPermanentlyDenied}, isRestricted: ${status.isRestricted}");
+      "Checking permission: $status, isGranted: ${status.isGranted}, isDenied: ${status.isDenied}, isPermanentlyDenied: ${status.isPermanentlyDenied}, isRestricted: ${status.isRestricted}",
+    );
 
     if (status.isGranted) {
       print("마이크 권한이 이미 허용되어 있습니다.");
@@ -81,7 +82,8 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (status.isPermanentlyDenied) {
       print("마이크 권한이 영구적으로 거부된 상태입니다. 설정에서 변경해주세요. (Check)");
       _showPermissionDeniedSnackBar(
-          "마이크 사용을 위해서는 권한이 필요합니다. 앱 설정에서 직접 마이크 권한을 허용해주세요.");
+        "마이크 사용을 위해서는 권한이 필요합니다. 앱 설정에서 직접 마이크 권한을 허용해주세요.",
+      );
       await openAppSettings();
       return false; // 설정 화면으로 보냈으므로 false 반환
     }
@@ -90,16 +92,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     // 여기서 다시 request를 호출합니다.
     final result = await Permission.microphone.request();
     print(
-        "Permission request result: $result, isGranted: ${result.isGranted}, isDenied: ${result.isDenied}, isPermanentlyDenied: ${result.isPermanentlyDenied}, isRestricted: ${result.isRestricted}");
+      "Permission request result: $result, isGranted: ${result.isGranted}, isDenied: ${result.isDenied}, isPermanentlyDenied: ${result.isPermanentlyDenied}, isRestricted: ${result.isRestricted}",
+    );
 
     if (result.isGranted) {
       print("마이크 권한이 허용되었습니다.");
       return true;
     } else if (result.isPermanentlyDenied) {
-      print(
-          "마이크 권한이 영구적으로 거부되었습니다. 설정에서 변경해주세요. (After request)");
+      print("마이크 권한이 영구적으로 거부되었습니다. 설정에서 변경해주세요. (After request)");
       _showPermissionDeniedSnackBar(
-          "마이크 권한이 영구적으로 거부되었습니다. 앱 설정에서 직접 권한을 허용해주세요.");
+        "마이크 권한이 영구적으로 거부되었습니다. 앱 설정에서 직접 권한을 허용해주세요.",
+      );
       await openAppSettings();
       return false;
     } else {
@@ -112,33 +115,36 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   // _requestMicrophonePermission 함수는 didChangeAppLifecycleState에서 사용될 수 있도록 유지
   Future<void> _requestMicrophonePermission() async {
-      var status = await Permission.microphone.status;
-      print("(Lifecycle) Initial permission status: $status, isGranted: ${status.isGranted}, isDenied: ${status.isDenied}, isPermanentlyDenied: ${status.isPermanentlyDenied}, isRestricted: ${status.isRestricted}");
+    var status = await Permission.microphone.status;
+    print(
+      "(Lifecycle) Initial permission status: $status, isGranted: ${status.isGranted}, isDenied: ${status.isDenied}, isPermanentlyDenied: ${status.isPermanentlyDenied}, isRestricted: ${status.isRestricted}",
+    );
 
-      if (status.isGranted) {
-          print("(Lifecycle) 마이크 권한이 이미 허용되었습니다.");
-          return;
-      }
+    if (status.isGranted) {
+      print("(Lifecycle) 마이크 권한이 이미 허용되었습니다.");
+      return;
+    }
 
-      if (status.isPermanentlyDenied) {
-          print("(Lifecycle) 마이크 권한이 영구적으로 거부된 상태입니다. 설정에서 변경해주세요. (Initial check)");
-          // 이 경우, 사용자가 앱으로 돌아올 때마다 설정으로 보내는 것은 사용자 경험에 좋지 않을 수 있습니다.
-          // _showPermissionDeniedSnackBar를 호출하거나, 앱 내 다른 UI로 안내할 수 있습니다.
-          // 여기서는 일단 로그만 남기고, 실제 권한 요청은 MicButton 클릭 시 _checkAndRequestMicrophonePermission 에서 처리하도록 합니다.
-          // _showPermissionDeniedSnackBar("마이크 권한이 영구적으로 거부되었습니다. 앱 설정에서 직접 권한을 허용해주세요.");
-          // await openAppSettings();
-          return;
-      }
+    if (status.isPermanentlyDenied) {
+      print(
+        "(Lifecycle) 마이크 권한이 영구적으로 거부된 상태입니다. 설정에서 변경해주세요. (Initial check)",
+      );
+      // 이 경우, 사용자가 앱으로 돌아올 때마다 설정으로 보내는 것은 사용자 경험에 좋지 않을 수 있습니다.
+      // _showPermissionDeniedSnackBar를 호출하거나, 앱 내 다른 UI로 안내할 수 있습니다.
+      // 여기서는 일단 로그만 남기고, 실제 권한 요청은 MicButton 클릭 시 _checkAndRequestMicrophonePermission 에서 처리하도록 합니다.
+      // _showPermissionDeniedSnackBar("마이크 권한이 영구적으로 거부되었습니다. 앱 설정에서 직접 권한을 허용해주세요.");
+      // await openAppSettings();
+      return;
+    }
 
-      // isDenied 또는 isRestricted인 경우, 앱이 foreground로 돌아올 때마다 자동으로 request를 호출하는 것은
-      // 사용자에게 반복적인 팝업을 띄울 수 있으므로, 여기서는 상태 확인만 하고 실제 요청은 사용자 인터랙션 시 하도록 합니다.
-      if (status.isDenied || status.isRestricted) {
-          print("(Lifecycle) 마이크 권한이 거부 또는 제한된 상태입니다. 사용자 액션 시 재요청 필요.");
-          // final result = await Permission.microphone.request();
-          // ... (이하 로직은 _checkAndRequestMicrophonePermission 과 유사하게 처리 가능하나, 여기서는 생략)
-      }
+    // isDenied 또는 isRestricted인 경우, 앱이 foreground로 돌아올 때마다 자동으로 request를 호출하는 것은
+    // 사용자에게 반복적인 팝업을 띄울 수 있으므로, 여기서는 상태 확인만 하고 실제 요청은 사용자 인터랙션 시 하도록 합니다.
+    if (status.isDenied || status.isRestricted) {
+      print("(Lifecycle) 마이크 권한이 거부 또는 제한된 상태입니다. 사용자 액션 시 재요청 필요.");
+      // final result = await Permission.microphone.request();
+      // ... (이하 로직은 _checkAndRequestMicrophonePermission 과 유사하게 처리 가능하나, 여기서는 생략)
+    }
   }
-
 
   void _showPermissionDeniedSnackBar(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
@@ -172,17 +178,16 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
   void _startChatWithDefaultAI(String inputText) {
     if (inputText.trim().isEmpty && mounted) {
-       // 입력된 텍스트가 없을 경우 (STT가 최종 결과를 반환했지만 내용이 없는 경우 등)
-       // 사용자에게 안내 메시지를 보여주거나, 아무 동작도 하지 않을 수 있습니다.
-       // 예를 들어, STT가 활성화 되었다가 아무 말 없이 종료되면 inputText가 비어있을 수 있습니다.
-       print("입력된 음성이 없습니다.");
-       // ScaffoldMessenger.of(context).showSnackBar(
-       //   SnackBar(content: Text("음성 입력이 없습니다. 다시 시도해주세요."))
-       // );
-       return;
+      // 입력된 텍스트가 없을 경우 (STT가 최종 결과를 반환했지만 내용이 없는 경우 등)
+      // 사용자에게 안내 메시지를 보여주거나, 아무 동작도 하지 않을 수 있습니다.
+      // 예를 들어, STT가 활성화 되었다가 아무 말 없이 종료되면 inputText가 비어있을 수 있습니다.
+      print("입력된 음성이 없습니다.");
+      // ScaffoldMessenger.of(context).showSnackBar(
+      //   SnackBar(content: Text("음성 입력이 없습니다. 다시 시도해주세요."))
+      // );
+      return;
     }
     if (inputText.trim().isEmpty) return;
-
 
     final defaultCharacter = {
       'name': '야옹이',
@@ -193,12 +198,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => ChatScreen(
-          characterName: defaultCharacter['name'] as String,
-          personalityTags: defaultCharacter['tags'] as List<String>,
-          greeting: defaultCharacter['greeting'] as String,
-          initialUserMessage: inputText,
-        ),
+        builder:
+            (context) => ChatScreen(
+              characterName: defaultCharacter['name'] as String,
+              personalityTags: defaultCharacter['tags'] as List<String>,
+              greeting: defaultCharacter['greeting'] as String,
+              initialUserMessage: inputText,
+            ),
       ),
     );
   }
@@ -235,9 +241,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           ),
           Padding(
             padding: const EdgeInsets.only(right: 16.0),
-            child:
-                CircleAvatar(backgroundImage: AssetImage('assets/profile.png')),
-          )
+            child: CircleAvatar(
+              backgroundImage: AssetImage('assets/profile.png'),
+            ),
+          ),
         ],
       ),
       body: _buildEmptyScreen(),


### PR DESCRIPTION
# 🗨️ 채팅 히스토리 화면 구현

## 📋 개요
사물 기반 AI 채팅 시스템의 채팅 히스토리 화면을 구현했습니다. 
사용자가 등록한 사물들과의 채팅 내역을 확인하고, 다른 사용자의 사물에 방문하여 대화한 내역도 함께 관리할 수 있습니다.

## ✨ 구현된 주요 기능

### 🎯 핵심 기능
- **사물 기반 채팅 리스트**: 사용자 중심이 아닌 사물(오브젝트) 중심의 채팅 히스토리
- **3단계 필터링**: 전체 / 내 모멘티 / @유저명으로 채팅 분류
- **새 채팅방 표시**: 빨간 점으로 새로운 채팅방 구분
- **실시간 상태 표시**: 온라인 상태, 읽지 않은 메시지 수, 반응 알림

### 🖼️ 시각적 요소
- **사물 프로필 사진**: 사물 등록 시 촬영한 실제 사물 이미지 (원형)
- **장소 사진**: 해당 사물이 위치한 장소의 이미지 (둥근 사각형)
- **방문자 태그**: 다른 사용자의 사물에 접근했을 때 "방문" 배지 표시
- **반응 알림**: 좋아요, 댓글 등의 상호작용 표시

### 📱 UI/UX 디자인
- **일관된 레이아웃**: 필터 버튼과 프로필 사진의 시작점 정렬
- **아이보리/화이트 테마**: 필터 영역은 아이보리, 리스트는 화이트 배경
- **적절한 여백**: 12-16px 패딩으로 모바일 친화적 간격
- **터치 친화적**: 각 채팅 아이템 탭 가능, 적절한 터치 영역

## 🏗️ 기술적 구현

### 📁 파일 구조
```
lib/screens/chat/
└── chat_history_screen.dart    # 메인 채팅 히스토리 화면
lib/screens/main/
├── home_screen.dart           # 홈 화면 (네비게이션 추가)
└── main.dart                  # 앱 진입점 수정
```

### 🎨 UI 컴포넌트
```dart
ChatHistoryScreen (StatefulWidget)
├── AppBar (아이보리 배경)
├── FilterButtons (전체/내모멘티/@유저명)
└── ChatList (ListView.builder)
    └── ChatHistoryItem (Material + InkWell)
        ├── 새 채팅방 빨간 점 (조건부)
        ├── 사물 프로필 사진 (Stack)
        │   ├── CircleAvatar
        │   ├── 온라인 상태 (초록 점)
        │   └── 읽지 않은 수 배지
        ├── 채팅 정보 (Column)
        │   ├── 사물명 + 방문 태그
        │   ├── 사용자명 + 반응 알림
        │   └── 마지막 메시지
        └── 장소 사진 (오른쪽)
```

### 📊 데이터 모델
```dart
class ChatHistoryItem {
  // 기본 정보
  final String id, username, objectName;
  final String lastMessage, timestamp;
  
  // 상태 정보
  final bool isOnline, hasUnread, isNewChat;
  final int unreadCount;
  
  // 이미지 정보
  final String objectPhoto;    // 사물 프로필 사진
  final String locationPhoto;  // 장소 사진
  
  // 분류 및 관계
  final String category;       // 'moments' | 'friends'
  final bool isVisitor;        // 방문자 여부
  final bool hasReaction;      // 반응 알림
}
```

## 🚧 현재 임시 구성 vs 실제 구현

### 📸 이미지 처리
**현재 (임시):**
```dart
objectPhoto: 'assets/profile.png'  // 모든 사물 동일 이미지
locationPhoto: 'assets/profile.png' // 모든 장소 동일 이미지
```

**실제 구현 예정:**
```dart
objectPhoto: "https://cdn.service.com/objects/user123_obj456.jpg"
locationPhoto: "https://cdn.service.com/locations/loc789.jpg"
// + CachedNetworkImage, 로딩/에러 처리
```

### 📡 데이터 소스
**현재 (임시):**
- 하드코딩된 7개 샘플 데이터
- 로컬 setState 상태 관리

**실제 구현 예정:**
- REST API / GraphQL 데이터 페칭
- 실시간 WebSocket 업데이트
- Provider/Riverpod 전역 상태 관리
- 오프라인 캐싱

### 🔄 상호작용
**현재 (임시):**
```dart
onTap: () => showDialog(...)  // 단순 다이얼로그
```

**실제 구현 예정:**
```dart
onTap: () => Navigator.push(context, 
  MaterialPageRoute(builder: (_) => ChatScreen(objectId: chat.id))
);
```

## 🧪 테스트 방법

### 📱 UI 테스트
1. 앱 실행 후 홈 화면에서 "채팅 히스토리" 버튼 탭
2. 필터 버튼 동작 확인:
   - "전체": 7개 모든 채팅 표시
   - "내 모멘티": 5개 자신의 사물 채팅 표시  
   - "@유저명": 2개 친구 사물 채팅 표시
3. 각 채팅 아이템 탭하여 다이얼로그 확인
4. 스크롤 동작 및 레이아웃 확인

### 🎯 확인 포인트
- ✅ 빨간 점이 새 채팅방에만 표시
- ✅ 읽지 않은 메시지 배지 (숫자)
- ✅ 방문자 태그 ("방문") 표시
- ✅ 반응 알림 ("❤️ 반응") 표시
- ✅ 필터 버튼과 프로필 사진 정렬
- ✅ 온라인 상태 (초록 점) 표시

## 🔮 향후 개선 계획

### 🔄 단기 개선사항 (다음 스프린트)
- [ ] 실제 API 연동
- [ ] 네트워크 이미지 로딩
- [ ] 실제 채팅 화면으로 네비게이션
- [ ] 로딩 상태 및 에러 처리

### 🚀 중기 개선사항
- [ ] 실시간 업데이트 (WebSocket)
- [ ] 무한 스크롤 페이지네이션
- [ ] 검색 기능
- [ ] 채팅방 삭제/숨김 기능

### 🎨 장기 개선사항
- [ ] 다크 테마 지원
- [ ] 접근성 개선 (VoiceOver 등)
- [ ] 애니메이션 및 마이크로 인터랙션
- [ ] 푸시 알림 연동

## 📷 스크린샷

```
[채팅 히스토리 화면]
- 아이보리 헤더 + 필터 버튼
- 화이트 배경 + 채팅 리스트
- 각종 상태 표시 (빨간점, 배지, 태그)
```

## 📝 관련 이슈
- 사물 기반 AI 채팅 시스템 설계
- 채팅 히스토리 UI/UX 개선
- 모바일 반응형 레이아웃

---

## 👀 리뷰 포인트
1. **데이터 모델 구조**가 실제 백엔드 API와 호환성이 있는지
2. **UI 컴포넌트 분리**가 재사용성을 고려했는지  
3. **성능 최적화** (ListView.builder 사용, 이미지 캐싱 준비)
4. **상태 관리 패턴**이 확장 가능한지

